### PR TITLE
Wicd flood its log with eroneous error when wired device is not configured

### DIFF
--- a/wicd/wnettools.py
+++ b/wicd/wnettools.py
@@ -927,12 +927,15 @@ class BaseWiredInterface(BaseInterface):
             carrier = open(carrier_path, 'r')
             try:
                 link = carrier.read().strip()
+            except (IOError):
+                return False
+            try:
                 link = int(link)
                 if link == 1:
                     return True
                 elif link == 0:
                     return False
-            except (IOError, ValueError, TypeError):
+            except (ValueError, TypeError):
                 print 'Error checking link using /sys/class/net/%s/carrier' \
                     % self.iface
                 


### PR DESCRIPTION
Read failure on /sys/class/net/*/carrier is not an error.
It happens when the device is not configured (at least on my debian).
