### PR TITLE
Backward uncompatibility with python-urwid > 1.3

### DIFF
--- a/curses/wicd-curses.py
+++ b/curses/wicd-curses.py
@@ -1141,9 +1141,11 @@ class appGUI():
         if not ui._started:
             return False
 
-        input_data = ui.get_input_nonblocking()
+        # input_data = ui.get_input_nonblocking()
+        ui.set_input_timeouts(max_wait=0)
+        input_data = ui.get_input()
         # Resolve any "alarms" in the waiting
-        self.handle_keys(input_data[1])
+        self.handle_keys(input_data) # [1]
 
         # Update the screen
         canvas = self.frame.render((self.size), True)


### PR DESCRIPTION
Wicd-curses doesn't work without it on Debian Sid. Tested there (not all features, but now it starts, connects and could change some settings).

Best regards.

For reference see:
https://bbs.archlinux.org/viewtopic.php?id=190578
https://technik.blogbasis.net/wicd-curses-fix-fuer-attributeerror-screen-object-no-attribute-get_input_nonblocking-04-12-2014
