### PR TITLE
prevent exception

### DIFF
--- a/wicd/wnettools.py
+++ b/wicd/wnettools.py
@@ -16,7 +16,7 @@ class BaseWirelessInterface() -- Control a wireless network interface.
 #   Copyright (C) 2007 - 2009 Adam Blackburn
 #   Copyright (C) 2007 - 2009 Dan O'Reilly
 #   Copyright (C) 2007 - 2009 Byron Hillis
-#   Copyright (C) 2009        Andrew Psaltis
+#   Copyright (C) 2009        Andrew Psaltisa
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License Version 2 as
@@ -683,7 +683,8 @@ class BaseInterface(object):
         else:
             print "ERROR: no dhcp client found"
             ret = None
-        self.dhcp_object.wait()
+        if self.dhcp_object:
+            self.dhcp_object.wait()
         return ret
         
     @neediface(False)

--- a/wicd/wnettools.py
+++ b/wicd/wnettools.py
@@ -16,7 +16,7 @@ class BaseWirelessInterface() -- Control a wireless network interface.
 #   Copyright (C) 2007 - 2009 Adam Blackburn
 #   Copyright (C) 2007 - 2009 Dan O'Reilly
 #   Copyright (C) 2007 - 2009 Byron Hillis
-#   Copyright (C) 2009        Andrew Psaltisa
+#   Copyright (C) 2009        Andrew Psaltis
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License Version 2 as


### PR DESCRIPTION
sometimes it can be None

DHCP connection failed
Exception in thread Thread-10:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/dist-packages/wicd/networking.py", line 350, in run
    self._connect()
  File "/usr/lib/python2.7/dist-packages/wicd/networking.py", line 941, in _connect
    self.set_ip_address(wiface)
  File "/usr/lib/python2.7/dist-packages/wicd/networking.py", line 73, in wrapper
    return func(self, ___args, *___kargs)
  File "/usr/lib/python2.7/dist-packages/wicd/networking.py", line 469, in set_ip_address
    dhcp_status = iface.StartDHCP(hname)
  File "/usr/lib/python2.7/dist-packages/wicd/wnettools.py", line 195, in newfunc
    return func(self, _args, *_kwargs)
  File "/usr/lib/python2.7/dist-packages/wicd/wnettools.py", line 622, in StartDHCP
    self.dhcp_object.wait()
AttributeError: 'NoneType' object has no attribute 'wait'
