### PR TITLE
fix: saving props for wifi fails (option -w)

### DIFF
--- a/cli/wicd-cli.py
+++ b/cli/wicd-cli.py
@@ -305,7 +305,7 @@ if options.wireless and options.list_encryption_types:
 if options.save and options.network > -1:
     if options.wireless:
         is_valid_wireless_network_id(options.network)
-        config.SaveWirelessNetworkProfile(options.network)
+        wireless.SaveWirelessNetworkProfile(options.network)
     elif options.wired:
         config.SaveWiredNetworkProfile(options.name)
     op_performed = True


### PR DESCRIPTION
running `wicd-cli -y -n 6 -p key -s aaa -w`
results in
`dbus.exceptions.DBusException: org.freedesktop.DBus.Error.UnknownMethod: Method "SaveWirelessNetworkProfile" with signature "i" on interface "org.wicd.daemon.config" doesn't exist`
