### PR TITLE
Fix guiutil.py self.entry.set_text(text)

### DIFF
--- a/gtk/guiutil.py
+++ b/gtk/guiutil.py
@@ -162,7 +162,7 @@ class LabelEntry(gtk.HBox):
     def set_text(self, text):
         """ Set text of the GtkEntry. """
         # For compatibility...
-        self.entry.set_text(text)
+        self.entry.set_text(str(text))
 
     def get_text(self):
         """ Get text of the GtkEntry. """


### PR DESCRIPTION
set_text expects a string while text sometimes can be of dbus.Int32 (not sure if bug from dbus or wicd-gtk but this fixes it).

  File "/usr/share/wicd/gtk/guiutil.py", line 165, in set_text
    self.entry.set_text(text)
TypeError: Gtk.Entry.set_text() argument 1 must be string, not dbus.Int32
